### PR TITLE
Fix error handling for unreadable response bodies due to redirects

### DIFF
--- a/requests_pprint/formatting.py
+++ b/requests_pprint/formatting.py
@@ -4,7 +4,8 @@ import json
 from typing import Any
 from xml.dom.minidom import Document, parseString
 
-from aiohttp import ClientRequest, ClientResponse, ContentTypeError
+from aiohttp import (ClientConnectionError, ClientRequest, ClientResponse,
+                     ContentTypeError)
 from multidict import CIMultiDict, CIMultiDictProxy
 from requests import PreparedRequest, Response
 from requests.structures import CaseInsensitiveDict
@@ -189,7 +190,10 @@ async def async_parse_response_body(response: ClientResponse) -> str | bytes:
         str | bytes: The parsed body of the response.
     """
     content_type: str = response.headers.get("Content-Type", "").lower()
-    content: bytes = await response.read()
+    try:
+        content: bytes = await response.read()
+    except ClientConnectionError:
+        return ""
     content_encoding: str = response.get_encoding()
     try:
         content_text: str = await response.text()


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->

Closes #95

## 📑 Description

<!-- Add a brief description of the pr -->

Improves error control in `async_parse_response_body` to handle cases where the response body cannot be read due to closed connections, particularly in scenarios involving redirects. This change prevents `ClientConnectionError` exceptions from interrupting the flow and returns an empty string instead.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks

<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->

- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ℹ Additional Information

<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
